### PR TITLE
Null-safety release

### DIFF
--- a/lib/app_bar/certificates_info_popup.dart
+++ b/lib/app_bar/certificates_info_popup.dart
@@ -900,7 +900,7 @@ class _CertificateInfoPopupState extends State<CertificateInfoPopup> {
                       recognizer: TapGestureRecognizer()..onTap = () async {
                         final taskId = await FlutterDownloader.enqueue(
                           url: cRLDistributionPoints.crls![i],
-                          savedDir: (await getExternalStorageDirectory()).path,
+                          savedDir: (await getExternalStorageDirectory())!.path,
                           showNotification: true, // show download progress in status bar (for Android)
                           openFileFromNotification: true, // click on notification to open downloaded file (for Android)
                         );
@@ -982,7 +982,7 @@ class _CertificateInfoPopupState extends State<CertificateInfoPopup> {
                       recognizer: TapGestureRecognizer()..onTap = () async {
                         final taskId = await FlutterDownloader.enqueue(
                           url: value,
-                          savedDir: (await getExternalStorageDirectory()).path,
+                          savedDir: (await getExternalStorageDirectory())!.path,
                           showNotification: true, // show download progress in status bar (for Android)
                           openFileFromNotification: true, // click on notification to open downloaded file (for Android)
                         );

--- a/lib/long_press_alert_dialog.dart
+++ b/lib/long_press_alert_dialog.dart
@@ -253,9 +253,9 @@ class _LongPressAlertDialogState extends State<LongPressAlertDialog> {
           String fileName = path.substring(path.lastIndexOf('/') + 1);
 
           final taskId = await FlutterDownloader.enqueue(
-            url: widget.hitTestResult.extra,
+            url: widget.hitTestResult.extra!,
             fileName: fileName,
-            savedDir: (await getExternalStorageDirectory()).path,
+            savedDir: (await getExternalStorageDirectory())!.path,
             showNotification: true,
             openFileFromNotification: true,
           );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+
 import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
@@ -58,7 +59,7 @@ void main() async {
             browserModel!.setCurrentWebViewModel(webViewModel);
             return browserModel;
           },
-          create: (BuildContext context) => BrowserModel(null),
+          create: (BuildContext context) => BrowserModel(WebViewModel()),
         ),
       ],
       child: FlutterBrowserApp(),

--- a/lib/models/browser_model.dart
+++ b/lib/models/browser_model.dart
@@ -272,7 +272,7 @@ class BrowserModel extends ChangeNotifier {
     SharedPreferences prefs = await SharedPreferences.getInstance();
     Map<String, dynamic> browserData;
     try {
-      browserData = await json.decode(prefs.getString("browser"));
+      browserData = await json.decode(prefs.getString("browser")!);
     } catch (e) {
       print(e);
       return;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,41 +43,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
-  convert:
-    dependency: transitive
-    description:
-      name: convert
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.1"
   crypto:
     dependency: "direct main"
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "3.0.1"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
-  device_info:
-    dependency: transitive
-    description:
-      name: device_info
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0-nullsafety.2"
-  device_info_platform_interface:
-    dependency: transitive
-    description:
-      name: device_info_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0-nullsafety.2"
+    version: "1.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -91,14 +70,14 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.0"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -110,42 +89,46 @@ packages:
       name: flutter_colorpicker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0-nullsafety.0"
+    version: "0.4.0"
   flutter_datetime_picker:
     dependency: "direct main"
     description:
-      name: flutter_datetime_picker
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.5.0"
+      path: "."
+      ref: master
+      resolved-ref: eb9701172da23121d8632369e5a6c4382bcc5e45
+      url: "https://github.com/Realank/flutter_datetime_picker.git"
+    source: git
+    version: "1.5.1"
   flutter_downloader:
     dependency: "direct main"
     description:
       name: flutter_downloader
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   flutter_icons:
     dependency: "direct main"
     description:
-      name: flutter_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
+      path: "."
+      ref: HEAD
+      resolved-ref: "0831af6f0f239d20fb9578612d7a893e2a53d044"
+      url: "https://github.com/adarsh-technocrat/flutter-icons.git"
+    source: git
+    version: "1.1.1-nullsafety.0"
   flutter_inappwebview:
     dependency: "direct main"
     description:
       name: flutter_inappwebview
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.3-nullsafety.1"
+    version: "5.3.2"
   flutter_svg:
     dependency: "direct main"
     description:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.21.0-nullsafety.0"
+    version: "0.22.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -157,7 +140,7 @@ packages:
     source: sdk
     version: "0.0.0"
   intl:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       name: intl
       url: "https://pub.dartlang.org"
@@ -218,70 +201,70 @@ packages:
       name: path_drawing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0-nullsafety.0"
+    version: "0.5.1"
   path_parsing:
     dependency: transitive
     description:
       name: path_parsing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0-nullsafety.0"
+    version: "0.2.1"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.27"
+    version: "2.0.1"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+2"
+    version: "2.0.0"
   path_provider_macos:
     dependency: transitive
     description:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+8"
+    version: "2.0.0"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+3"
+    version: "2.0.1"
   permission_handler:
     dependency: "direct main"
     description:
       name: permission_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0+2"
+    version: "8.0.0+1"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "3.5.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.0"
   platform:
     dependency: transitive
     description:
@@ -295,77 +278,77 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "2.0.0"
   process:
     dependency: transitive
     description:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.1"
   provider:
     dependency: "direct main"
     description:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0-nullsafety.5"
+    version: "5.0.0"
   share:
     dependency: "direct main"
     description:
       name: share
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   share_extend:
     dependency: "direct main"
     description:
       name: share_extend
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.9"
+    version: "2.0.0"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.12+4"
+    version: "2.0.5"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.2+4"
+    version: "2.0.0"
   shared_preferences_macos:
     dependency: transitive
     description:
       name: shared_preferences_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+11"
+    version: "2.0.0"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2+7"
+    version: "2.0.0"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.2+3"
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -426,7 +409,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.0.4"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -447,7 +430,7 @@ packages:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   url_launcher_web:
     dependency: transitive
     description:
@@ -462,13 +445,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
-  uuid:
-    dependency: "direct overridden"
-    description:
-      name: uuid
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:
@@ -482,21 +458,21 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.4+1"
+    version: "2.0.5"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.2.0"
   xml:
     dependency: transitive
     description:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.2"
+    version: "5.1.1"
 sdks:
-  dart: ">=2.12.0-259.9.beta <3.0.0"
-  flutter: ">=1.24.0-10.2.pre"
+  dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.24.0-7.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.1.0+4
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -26,18 +26,30 @@ dependencies:
   flutter_inappwebview: ^5.0.3-nullsafety.1
     # path: /Users/lorenzopichilli/Desktop/flutter_inappwebview
   flutter_downloader: ^1.5.2
-  path_provider: ^1.6.27
-  permission_handler: ^5.1.0+2
+  path_provider: ^2.0.1
+  permission_handler: ^8.0.0
   provider: ^5.0.0-nullsafety.5
   share: ^2.0.0
-  share_extend: ^1.1.9
+  share_extend: ^2.0.0
   # charts_flutter: ^0.9.0
-  flutter_datetime_picker: ^1.5.0
-  crypto: ^2.1.5
-  shared_preferences: ^0.5.12+4
+  # flutter_datetime_picker: ^1.5.0
+  #Null-safe https://github.com/Realank/flutter_datetime_picker/issues/241
+  flutter_datetime_picker:
+    git:
+      url: https://github.com/Realank/flutter_datetime_picker.git
+      ref: master
+
+  crypto: ^3.0.1
+  shared_preferences: ^2.0.5
   package_info: ^2.0.0
-  flutter_icons: ^1.1.0
-  flutter_svg: ^0.21.0-nullsafety.0
+  #flutter_icons: ^1.1.0
+  #Null-safe https://github.com/flutter-studio/flutter-icons/issues/41
+  flutter_icons:
+    git:
+      url: https://github.com/adarsh-technocrat/flutter-icons.git
+      branch: null-safety-migration
+
+  flutter_svg: ^0.22.0
   mime: ^1.0.0
   url_launcher: ^6.0.0
   # cached_network_image: ^2.5.0
@@ -47,14 +59,17 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
 
+  #
+  intl: ^0.17.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
   # flutter_launcher_icons: ^0.8.1
 
-dependency_overrides:
-  intl: ^0.17.0
-  uuid: ^2.0.2
+# dependency_overrides:
+# intl: ^0.17.0
+ # uuid: ^3.0.4
 
 flutter_icons:
   android: "launcher_icon"


### PR DESCRIPTION
Null-safety release: update all dependecies to uptodate major versions. 2 dependecies (flutter_icons and flutter_datetime_picker) were taken not from official repos because there are no null-safety offical versions.